### PR TITLE
Resolved naming conflict and encode/decode problem

### DIFF
--- a/scripts/ingestion/parsers/publish_parser.py
+++ b/scripts/ingestion/parsers/publish_parser.py
@@ -4,7 +4,7 @@ from ..database.db_main import open_db, close_db
 
 def parse_packagelist(date, ARCH, db_location, DFSG):
     con = open_db(db_location)
-    with open(f'./ingestion/parsers/Packagelist_DUMP/{date}-{ARCH}-{DFSG}_Packages','r') as rf:
+    with open(f'./ingestion/parsers/Packagelist_DUMP/{date}-{ARCH}-{DFSG}_Packages.dump','r', encoding='utf-8') as rf:
         header = ""
         for line in rf:
             if line == "\n":
@@ -30,7 +30,7 @@ def parse_packagelist(date, ARCH, db_location, DFSG):
 
 def parse_dependencylist(date, ARCH, db_location, DFSG):
     con = open_db(db_location)
-    with open(f'./ingestion/parsers/Packagelist_DUMP/{date}-{ARCH}-{DFSG}_Packages','r') as rf:
+    with open(f'./ingestion/parsers/Packagelist_DUMP/{date}-{ARCH}-{DFSG}_Packages.dump','r', encoding='utf-8') as rf:
         header = ""
         for line in rf:
             if line == "\n":


### PR DESCRIPTION
All data files now end with Packages.dump. Add "encoding = 'utf-8'" to the publish_parser file handling to elimate the UnicodeDecodeError. Tested on 2016-2017 data. @absol27 please take a look at this.